### PR TITLE
Resolves issue when Figma was unable to fetch fonts due to CORS misconfiguration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask==1.0.2
+flask-cors
+

--- a/server.py
+++ b/server.py
@@ -7,11 +7,12 @@ import io
 import os
 import sys
 from flask import Flask, jsonify, send_file, request, make_response
-
+from flask_cors import CORS
 from helpers import get_font_list, is_valid_origin
 
 
 app = Flask(__name__)
+CORS(app)
 
 HTTP_PORT = 18412
 HTTPS_PORT = 7335
@@ -113,6 +114,6 @@ if __name__ == '__main__':
         else:
             hostname = sys.argv[1]
     else:
-        hostname = "127.0.0.1"
+        hostname = "0.0.0.0"
 
     app.run(host=hostname, port=HTTP_PORT)


### PR DESCRIPTION
### The problem

`server.py` doesn't allow CORS requests from `figma.com`, so Figma was unable to fetch local fonts. In browser console on Figma.com you can see the following error message:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://127.0.0.1:18412/figma/font-files. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).
```

On the local server, there is just one request logged as follows:

```
$ python server.py 
 * Serving Flask app "server" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://0.0.0.0:18412/ (Press CTRL+C to quit)
127.0.0.1 - - [03/Mar/2021 21:39:07] "GET /figma/font-files HTTP/1.1" 200 -
```

### The proposed solution

I've installed the [Flask-CORS](https://flask-cors.readthedocs.io/en/latest/) package that takes care of the CORS issue with a single line of code.

I've also changed the default binding address for the server to `0.0.0.0`, because on some systems it seems that `127.0.0.1` only allows connections on the loopback interface. This is unrelated to the CORS issue, but I think is an improvement.

