### PR TITLE
Fix attachment_filename in flask and  add python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
 flask-cors
+python-dotenv==1.0.0

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ def font_file():
             with open(file_name, 'rb') as bites:
                 response = make_response(send_file(
                     io.BytesIO(bites.read()),
-                    attachment_filename=os.path.basename(file_name),
+                    download_name=os.path.basename(file_name),
                     mimetype='application/octet-stream'
                 ))
 


### PR DESCRIPTION
This fixes two small issues:

- `attachment_filename` was replaced with `download_name` in flask (see: https://github.com/pallets/flask/pull/4667)
- On startup the server logged: `Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them` so I added it to the `requirements.txt`